### PR TITLE
Add more verbose messages to instance lock

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -343,7 +343,13 @@ static int initialize() {
     if (!cc_config.allow_multiple_clients) {
         retval = wait_client_mutex(".", 10);
         if (retval) {
-            log_message_error("Another instance of BOINC is running.");
+            if (retval == ERR_ALREADY_RUNNING) {
+                log_message_error("Another instance of BOINC is running.");
+            } else if (retval == ERR_OPEN) {
+                log_message_error("Failed to open lockfile. Check file/directory permissions.");
+            } else {
+                log_message_error("Failed to lock directory.", retval);
+            }
             return ERR_EXEC;
         }
     }


### PR DESCRIPTION
There may be situations where the lock may not be acquired even though there are no other instances of BOINC. This adds error messages for these cases

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
